### PR TITLE
deasync version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "chalk": "^0.5.1",
     "coffee-script": "^1.8.0",
-    "deasync": "0.0.7",
+    "deasync": "~0.0.7",
     "pygmentize-bundled": "^2.3.0",
     "underscore": "^1.7.0"
   },


### PR DESCRIPTION
As long as [`deasync`](https://www.npmjs.com/package/deasync) follows semvar, `pryjs` should get the latest patch version and will not break.