### PR TITLE
Fix pry.js for node 4.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: node_js
 
+sudo: required
+
+services:
+  - docker
+
 node_js:
   - 0.10.33
   - 4.1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ node_js:
   - 0.10.33
   - 4.1.1
 
-before_script:
-  - npm install -g mocha
-  - npm install -g coffee-script
-
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
   - 0.10.33
+  - 4.1.1
 
 before_script:
   - npm install -g mocha

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Pry like ability in javascript.",
   "main": "lib/pry.js",
   "scripts": {
-    "test": "mocha --recursive --reporter=mocha-pride --compilers coffee:coffee-script/register ./tests && ./node_modules/.bin/cucumber.js"
+    "test": "./node_modules/.bin/mocha --recursive --reporter=mocha-pride --compilers coffee:coffee-script/register ./tests && ./node_modules/.bin/cucumber.js"
   },
   "author": "blainesch",
   "license": "MIT",
@@ -21,6 +21,7 @@
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-coffee": "^0.12.0",
+    "mocha": "^2.3.3",
     "mocha-pride": "0.0.2",
     "sinon": "^1.12.1"
   },

--- a/src/pry/sync_prompt.coffee
+++ b/src/pry/sync_prompt.coffee
@@ -21,7 +21,7 @@ class MultilineState
       input.cli.setPrompt(prompt.replace(/[^>](?!$)/g, '-'))
     else
       input.cli.setPrompt(prompt.replace(/.(?!$)/g, '.'))
-    input.cli._refreshLine()
+    input.cli.prompt()
 
 class SinglelineState
 


### PR DESCRIPTION
The private function is undocumented and no longer works in versions of
node >4. This was tested on v0.10.33 and v4.1.1.